### PR TITLE
twitter cards plugin

### DIFF
--- a/twittercards/languages/en_US.json
+++ b/twittercards/languages/en_US.json
@@ -1,0 +1,18 @@
+{
+	"plugin-data":
+	{
+		"name": "Twitter Cards",
+		"description": "With Twitter Cards, you can attach rich photos, videos and media experience to Tweets that drive traffic to your website.",
+		"author": "SpecKtator",
+		"email": "specktator@totallynoob.com",
+		"website": "http://totallynoob.com",
+		"version": "0.1",
+		"releaseDate": "2015-12-11"
+	},
+	"twitterusername": "Twitter Username",
+	"twittercardtypepost": "Twitter card type for posts",
+	"twittercardtypepage": "Twitter card type for pages",
+	"complete-this-field-with-the-twitter-sites-owner-username": "Complete this field with site's owner twitter username.",
+	"complete-this-field-with-the-twitter-card-type-for-post": "Complete this field with the twitter card type for posts (default: summary)",
+	"complete-this-field-with-the-twitter-card-type-for-page": "Complete this field with the twitter card type for posts (default: summary_large_image)"
+}

--- a/twittercards/languages/ru_RU.json
+++ b/twittercards/languages/ru_RU.json
@@ -1,0 +1,13 @@
+{
+	"plugin-data":
+	{
+		"name": "Twitter Cards",
+		"description": "Протокол Twitter Cards дает возможность связывать свой контент с социальными сетями."
+	},
+	"twitterusername": "Twitter Username",
+	"twittercardtypepost": "Twitter card type for posts",
+	"twittercardtypepage": "Twitter card type for pages",
+	"complete-this-field-with-the-twitter-sites-owner-username": "Complete this field with site's owner twitter username.",
+	"complete-this-field-with-the-twitter-card-type-for-post": "Complete this field with the twitter card type for posts (default: summary)",
+	"complete-this-field-with-the-twitter-card-type-for-page": "Complete this field with the twitter card type for posts (default: summary_large_image)"
+}

--- a/twittercards/plugin.php
+++ b/twittercards/plugin.php
@@ -1,0 +1,124 @@
+<?php
+
+class pluginTwitterCards extends Plugin {
+
+	private function getImage($content)
+	{
+		$dom = new DOMDocument();
+		$dom->loadHTML('<meta http-equiv="content-type" content="text/html; charset=utf-8">'.$content);
+		$finder = new DomXPath($dom);
+
+		$images = $finder->query("//img[contains(@class, 'bludit-img-opengraph')]");
+
+		if($images->length==0) {
+			$images = $finder->query("//img");
+		}
+
+		if($images->length>0)
+		{
+			// First image from the list
+			$image = $images->item(0);
+			// Get value from attribute src
+			$imgSrc = $image->getAttribute('src');
+			// Returns the image src
+			return $imgSrc;
+		}
+
+		return false;
+	}
+
+	public function init()
+	{
+	    $this->dbFields = array(
+	        'twitter-username'=>"@siteowner's twitter name",
+	        'twitter-card-type-post'=>'summary',
+	        'twitter-card-type-page'=>'summary_large_image'
+	    );
+	}
+	
+	public function form()
+	{
+	    global $Language;
+	    $html  = '<div>';
+	    $html .= '<label for="twitter-username">'.$Language->get('twitterusername').'</label>';
+	    $html .= '<input type="text" name="twitter-username" value="'.$this->getDbField('twitter-username').'" />';
+	    $html .= '<div class="tip">'.$Language->get("complete-this-field-with-the-twitter-card-type-for-post").'</div>';
+
+	    $html .= '<label for="twitter-card-type-post">'.$Language->get('twittercardtypepost').'</label>';
+	    $html .= '<input type="text" name="twitter-card-type-post" value="'.$this->getDbField('twitter-card-type-post').'" />';
+	    $html .= '<div class="tip">'.$Language->get("complete-this-field-with-the-twitter-card-type-for-page").'</div>';
+
+	    $html .= '<label for="twitter-card-type-page">'.$Language->get('twittercardtypepage').'</label>';
+	    $html .= '<input type="text" name="twitter-card-type-page" value="'.$this->getDbField('twitter-card-type-page').'" />';
+	    $html .= '<div class="tip">'.$Language->get("complete-this-field-with-the-twitter-card-type-for-page").'</div>';
+
+	    $html .= '</div>';
+	    return $html;
+	}
+
+
+	public function siteHead()
+	{
+		global $Url, $Site;
+		global $Post, $Page, $posts, $dbUsers;
+
+		$admin = $dbUsers->getDb( 'admin' );
+
+		$twcd = array(
+			'locale'	=>$Site->locale(),
+			'type'		=>'summary',
+			'site'		=> $this->getDbField('twitter-username'),
+			'creator'	=> '',
+			'title'		=>$Site->title(),
+			'description'	=>$Site->description(),
+			'url'		=>$Site->url(),
+			'image'		=> '',
+			'siteName'	=>$Site->title()
+		);
+
+		switch($Url->whereAmI())
+		{
+			case 'post':
+				$twcd['type']		= $this->getDbField('twitter-card-type-post');
+				$twcd['site']		= $this->getDbField('twitter-username'); // admin's twitter username
+				$twcd['creator']		= $dbUsers->getDb( $Post->username() )['lastName']; //author's twitter username
+				$twcd['title']		= mb_substr($Post->title(), 0, 70, "UTF-8").' | '.$twcd['title'];
+				$twcd['description']	= mb_substr($Post->description(), 0, 200, "UTF-8");
+				$twcd['url']		= $Post->permalink(true);
+
+				$content = $Post->content();
+				break;
+
+			case 'page':
+				$twcd['type']		= $this->getDbField('twitter-card-type-page');
+				$twcd['site']		= $this->getDbField('twitter-username'); // admin's twitter username
+				$twcd['creator']	= $dbUsers->getDb( $Page->username() )['lastName']; //author's twitter username
+				$twcd['title']		= mb_substr($Page->title(), 0, 70, "UTF-8").' | '.$twcd['title'];
+				$twcd['description']	= mb_substr($Page->description(), 0, 200, "UTF-8");
+				$twcd['url']		= $Page->permalink(true);
+
+				$content = $Page->content();
+				break;
+
+			default:
+				$content = isset($posts[0])?$posts[0]->content():'';
+				break;
+		}
+
+		$html  = PHP_EOL.'<!-- Twitter Cards -->'.PHP_EOL;
+		$html .= '<meta property="twitter:card" content="'.$twcd['type'].'">'.PHP_EOL;
+		$html .= '<meta property="twitter:site" content="'.$twcd['site'].'">'.PHP_EOL; // twitter usernames
+		$html .= '<meta property="twitter:creator" content="'.$twcd['creator'].'">'.PHP_EOL; // twitter usernames
+		$html .= '<meta property="twitter:title" content="'.$twcd['title'].'">'.PHP_EOL;
+		$html .= '<meta property="twitter:description" content="'.$twcd['description'].'">'.PHP_EOL;
+
+		// Get the image from the content
+		$src = $this->getImage( $content );
+		if($src!==false) {
+			$twcd['image'] = $Site->domain().$src;
+			$html .= '<meta property="twitter:image" content="'.$twcd['image'].'">'.PHP_EOL;
+		}
+
+		return $html;
+	}
+}


### PR DESCRIPTION
twitter cards plugin
# Twitter Cards plugin for Bludit
1. The **site's owner** or the official twitter username must be filled in plugin's configuration page.
2. Temporarily the **creator/author** of the post needs to fill his/her twitter username at `Last Name` field of the profile page.
3. The user can choose twitter card's type for posts and pages. The values can be `summary` or `summary_large_image`.
4. Strips down the description and title of the card to 200 characters and 70 characters accordingly (supports UTF-8 characters too).
