### PR TITLE
CKeditor filemanager fix

### DIFF
--- a/ckeditor/libs/filemanager/config/config.php
+++ b/ckeditor/libs/filemanager/config/config.php
@@ -68,7 +68,7 @@ $config = array(
 	| with start and final /
 	|
 	*/
-	'upload_dir' => 'bl-content/uploads/',
+	'upload_dir' => 'content/uploads/',
 
 	/*
 	|--------------------------------------------------------------------------


### PR DESCRIPTION
Fixed path so that file will be referenced to the correct path.
