### PR TITLE
Added plugin: customFields

### DIFF
--- a/custom_fields/README.md
+++ b/custom_fields/README.md
@@ -1,0 +1,20 @@
+This plugin allows you to define custom fields in your template,
+which will be editable in the plugin settings.
+
+You can define available fields with their default values
+by using the following code:
+
+`<?php
+ $customFields->add([
+ 	'firstPageTitle' => 'Homepage',
+ 	'ctaLink' => '#contact',
+ 	'ctaText' => 'Contact',
+ ]);
+ ?>`
+ 
+ After that, you can acces those fields within your template
+ with the following code:
+ 
+ `<?php
+  echo $customFields->get('myfield');
+  ?>`

--- a/custom_fields/README.md
+++ b/custom_fields/README.md
@@ -4,17 +4,17 @@ which will be editable in the plugin settings.
 You can define available fields with their default values
 by using the following code:
 
-`<?php
- $customFields->add([
+<pre lang="javascript"><code>
+ $customFields->define([
  	'firstPageTitle' => 'Homepage',
  	'ctaLink' => '#contact',
  	'ctaText' => 'Contact',
  ]);
- ?>`
+ </code></pre>
  
  After that, you can acces those fields within your template
  with the following code:
  
- `<?php
-  echo $customFields->get('myfield');
-  ?>`
+ <pre lang="javascript"><code>
+  $customFields->get('myfield');
+</code></pre>

--- a/custom_fields/languages/de_DE.json
+++ b/custom_fields/languages/de_DE.json
@@ -1,0 +1,7 @@
+{
+	"plugin-data":
+	{
+		"name": "Benutzerdefinierte Template-Einstellungen",
+		"description": "Setze eigene Einstellungen in deinem Template"
+	}
+}

--- a/custom_fields/languages/de_DE.json
+++ b/custom_fields/languages/de_DE.json
@@ -2,6 +2,6 @@
 	"plugin-data":
 	{
 		"name": "Benutzerdefinierte Template-Einstellungen",
-		"description": "Setze eigene Einstellungen in deinem Template"
+		"description": "Setze eigene Einstellungen in deinem Template. Das verwendete Template muss dieses Plugin unterstützen, oder du kannst es selbst anpassen. Anleitung: Einen Parameter kannst du in deinem Template mit dem folgenden Code einbinden: <em>$customFields->get('myParameter')</em>"
 	}
 }

--- a/custom_fields/languages/en_US.json
+++ b/custom_fields/languages/en_US.json
@@ -2,6 +2,6 @@
 	"plugin-data":
 	{
 		"name": "Custom Template Parameters",
-		"description": "Add custom settings to your template"
+		"description": "Add custom settings to your template. Your template has to support this plugin, or you can edit it to fit your needs. To add a parameter to your template, use the following code: <em>$customFields->get('myparameter')</em>"
 	}
 }

--- a/custom_fields/languages/en_US.json
+++ b/custom_fields/languages/en_US.json
@@ -1,0 +1,7 @@
+{
+	"plugin-data":
+	{
+		"name": "Custom Template Parameters",
+		"description": "Add custom settings to your template"
+	}
+}

--- a/custom_fields/metadata.json
+++ b/custom_fields/metadata.json
@@ -1,0 +1,10 @@
+{
+	"author": "janxb",
+	"email": "bludit@janbrodda.de",
+	"website": "https://github.com/janxb",
+	"version": "1.0",
+	"releaseDate": "2016-05-28",
+	"license": "MIT",
+	"compatible": "1.4",
+	"notes": "For using this plugin, your template has to support custom template parameters"
+}

--- a/custom_fields/metadata.json
+++ b/custom_fields/metadata.json
@@ -3,7 +3,7 @@
 	"email": "bludit@janbrodda.de",
 	"website": "https://github.com/janxb",
 	"version": "1.0",
-	"releaseDate": "2016-05-28",
+	"releaseDate": "2016-07-22",
 	"license": "MIT",
 	"compatible": "1.4",
 	"notes": "For using this plugin, your template has to support custom template parameters"

--- a/custom_fields/plugin.php
+++ b/custom_fields/plugin.php
@@ -6,6 +6,7 @@ class pluginCustomFields extends Plugin
 	const FIELD_KEY = 'customFields';
 
 	private $addedFields = array();
+	private $isDefined = false;
 
 	public function init()
 	{
@@ -89,10 +90,13 @@ class pluginCustomFields extends Plugin
 		return $this->fields->$key;
 	}
 
-	public function add($keys)
+	public function define($keys)
 	{
 		if (!$this->installed())
 			return false;
+
+		if ($this->isDefined)
+			throw new Exception('You can only define custom fields once in your template');
 
 
 		if (!isset($this->fields))
@@ -107,6 +111,6 @@ class pluginCustomFields extends Plugin
 
 		$this->save();
 
-
+		$this->isDefined = true;
 	}
 }

--- a/custom_fields/plugin.php
+++ b/custom_fields/plugin.php
@@ -1,0 +1,106 @@
+<?php
+
+class pluginCustomFields extends Plugin
+{
+	private $fields;
+	const FIELD_KEY = 'customFields';
+
+	private $addedFields = array();
+
+	public function init()
+	{
+		$this->dbFields = array(
+			$this::FIELD_KEY => '{}'
+		);
+
+		$GLOBALS[$this::FIELD_KEY] = $this;
+	}
+
+	public function load()
+	{
+		$fieldsJson = $this->getDbField($this::FIELD_KEY, false);
+		$this->fields = json_decode($fieldsJson);
+	}
+
+	public function save()
+	{
+		if (!$this->installed())
+			return;
+
+		// Remove empty fields, which are not in use by templates
+		foreach ($this->fields as $key => $value) {
+			if (!in_array($key, $this->addedFields))
+				unset($this->fields->$key);
+		}
+
+		$fieldsJson = json_encode($this->fields);
+		$this->dbFields[$this::FIELD_KEY] = $fieldsJson;
+		$this->setDb($this->dbFields);
+	}
+
+	public function form()
+	{
+		$html = '';
+
+		$html .= '<div>';
+		$html .= '<input type="hidden" id="fieldJson" name="' . $this::FIELD_KEY . '" value="' . $this->getDbField($this::FIELD_KEY) . '" />';
+		$html .= '</div>';
+		$html .= '<div id="fieldInputs"></div>';
+
+		$html .= '
+		<script>
+			var $jsonInput = $("#fieldJson");
+			var $inputContainer = $("#fieldInputs");
+			var $form = $jsonInput.closest("form");
+			var $data = JSON.parse($jsonInput.val());
+			$.each($data, function( index, value ) {
+  				$inputContainer.append("<label><b>"+index+"</b></label>"); 
+  				$inputContainer.append("<input type=\'text\' name=\'"+index+"\' value=\'"+value+"\'>"); 
+  				$inputContainer.append("<br><br>"); 
+			});
+			
+			$form.submit(function(){
+				var newData = {};
+
+				$.each($inputContainer.children("input"), function( index, input ) {
+					$input = $(input);
+					newData[$input.attr("name")] = $input.val();
+				});
+				
+				$jsonInput.val(JSON.stringify(newData));
+			})
+		</script>';
+
+		return $html;
+	}
+
+	public function get($key)
+	{
+		if (!$this->installed())
+			return false;
+
+		if (!isset($this->fields))
+			$this->load();
+
+		if (!isset($this->fields->$key))
+			$this->add($key);
+
+		return $this->fields->$key;
+	}
+
+	public function add($key, $defaultValue = '')
+	{
+		if (!$this->installed())
+			return false;
+
+		array_push($this->addedFields, $key);
+
+		if (!isset($this->fields))
+			$this->load();
+
+		if (!isset($this->fields->$key)) {
+			$this->fields->$key = $defaultValue;
+			$this->save();
+		}
+	}
+}

--- a/custom_fields/plugin.php
+++ b/custom_fields/plugin.php
@@ -29,8 +29,9 @@ class pluginCustomFields extends Plugin
 
 		// Remove empty fields, which are not in use by templates
 		foreach ($this->fields as $key => $value) {
-			if (!in_array($key, $this->addedFields))
+			if (!in_array($key, $this->addedFields)) {
 				unset($this->fields->$key);
+			}
 		}
 
 		$fieldsJson = json_encode($this->fields);
@@ -83,24 +84,29 @@ class pluginCustomFields extends Plugin
 			$this->load();
 
 		if (!isset($this->fields->$key))
-			$this->add($key);
+			throw new Exception("Template Parameter $key is not declared");
 
 		return $this->fields->$key;
 	}
 
-	public function add($key, $defaultValue = '')
+	public function add($keys)
 	{
 		if (!$this->installed())
 			return false;
 
-		array_push($this->addedFields, $key);
 
 		if (!isset($this->fields))
 			$this->load();
 
-		if (!isset($this->fields->$key)) {
-			$this->fields->$key = $defaultValue;
-			$this->save();
+		foreach ($keys as $key => $defaultValue) {
+			if (!isset($this->fields->$key)) {
+				$this->fields->$key = $defaultValue;
+			}
+			array_push($this->addedFields, $key);
 		}
+
+		$this->save();
+
+
 	}
 }


### PR DESCRIPTION
This plugin allows a template to define custom settings, which can be edited in the bludit backend.
Thise settings could for example be an contact email address or other fields which are used in the template. This allows you to customize it even more.

After the first frontend page is requested, the defined custom fields can be edited in the plugin settings.
When you change your template or disable the plugin, unused custom fields are deleted and reset to their default values.

For code examples, please see the README.md file.
