### PR TITLE
Custom Image Dimensions

### DIFF
--- a/CustomImageDimensions/README..md
+++ b/CustomImageDimensions/README..md
@@ -1,0 +1,14 @@
+Custom Image Dimensions
+==========
+
+This plugin uses jQuery to allow you to set custom dimensions for your images directly on markdown.
+
+To set image dimensions you just use: `![Test image heigh=X width=Y](http://link.to/your_image)`.
+
+Where X and Y should be any value in pixels (% values will not work).
+
+Versions
+--------
+
+0.1, August 24, 2016
+- Release.

--- a/CustomImageDimensions/languages/en_US.json
+++ b/CustomImageDimensions/languages/en_US.json
@@ -1,0 +1,7 @@
+{
+	"plugin-data":
+	{
+		"name": "Custom Image Dimensions",
+		"description": "This plugin allow you to set custom dimensions for your images directly on your markdown"
+	}
+}

--- a/CustomImageDimensions/metadata.json
+++ b/CustomImageDimensions/metadata.json
@@ -1,0 +1,10 @@
+{
+	"author": "Alexandre Teles",
+	"email": "contato@alexteles.com",
+	"website": "https://alexteles.com",
+	"version": "0.1",
+	"releaseDate": "2016-08-24",
+	"license": "MIT",
+	"compatible": "1.4",
+	"notes": ""
+}

--- a/CustomImageDimensions/plugin.php
+++ b/CustomImageDimensions/plugin.php
@@ -1,0 +1,39 @@
+<?php
+
+class pluginCustomImageDimensions extends Plugin {
+
+	public function siteBodyEnd()
+	{
+		$pluginPath = $this->htmlPath();
+		$html  = '<script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.slim.min.js"></script>';
+		$html .= '
+        <script>
+            $("img").each(function(){  
+                imgAlt = this.alt;
+                if(/height=/i.test(imgAlt)){
+                    heightPosition = imgAlt.lastIndexOf("height=") + 7;
+                    height = heightPosition;
+                    for(i = heightPosition; i < imgAlt.length; i++){
+                        if(!isNaN(parseInt(imgAlt.substring(i)))){
+                            height += 1;
+                        } else break;
+                    }
+                    this.style.setProperty("height", imgAlt.substring(heightPosition, height));
+                }
+                if(/width=/i.test(imgAlt)){
+                    widthPosition = imgAlt.lastIndexOf("width=") + 6;
+                    width = widthPosition;
+                    for(i = widthPosition; i < imgAlt.length; i++){
+                        if(!isNaN(parseInt(imgAlt.substring(i)))){
+                            width += 1;
+                        } else break;
+                    }
+                    this.style.setProperty("width", imgAlt.substring(widthPosition, width));
+                }
+			});
+        </script>
+		';
+		
+		return $html;	
+	}
+}

--- a/CustomImageDimensions/plugin.php
+++ b/CustomImageDimensions/plugin.php
@@ -7,31 +7,31 @@ class pluginCustomImageDimensions extends Plugin {
 		$pluginPath = $this->htmlPath();
 		$html  = '<script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.slim.min.js"></script>';
 		$html .= '
-        <script>
-            $("img").each(function(){  
-                imgAlt = this.alt;
-                if(/height=/i.test(imgAlt)){
-                    heightPosition = imgAlt.lastIndexOf("height=") + 7;
-                    height = heightPosition;
-                    for(i = heightPosition; i < imgAlt.length; i++){
-                        if(!isNaN(parseInt(imgAlt.substring(i)))){
-                            height += 1;
-                        } else break;
-                    }
-                    this.style.setProperty("height", imgAlt.substring(heightPosition, height));
-                }
-                if(/width=/i.test(imgAlt)){
-                    widthPosition = imgAlt.lastIndexOf("width=") + 6;
-                    width = widthPosition;
-                    for(i = widthPosition; i < imgAlt.length; i++){
-                        if(!isNaN(parseInt(imgAlt.substring(i)))){
-                            width += 1;
-                        } else break;
-                    }
-                    this.style.setProperty("width", imgAlt.substring(widthPosition, width));
-                }
-			});
-        </script>
+		        <script>
+		            $("img").each(function(){  
+		                imgAlt = this.alt;
+		                if(/height=/i.test(imgAlt)){
+		                    heightPosition = imgAlt.lastIndexOf("height=") + 7;
+		                    height = heightPosition;
+		                    for(i = heightPosition; i < imgAlt.length; i++){
+		                        if(!isNaN(parseInt(imgAlt.substring(i)))){
+		                            height += 1;
+		                        } else break;
+		                    }
+		                    this.style.setProperty("height", imgAlt.substring(heightPosition, height));
+		                }
+		                if(/width=/i.test(imgAlt)){
+		                    widthPosition = imgAlt.lastIndexOf("width=") + 6;
+		                    width = widthPosition;
+		                    for(i = widthPosition; i < imgAlt.length; i++){
+		                        if(!isNaN(parseInt(imgAlt.substring(i)))){
+		                            width += 1;
+		                        } else break;
+		                    }
+		                    this.style.setProperty("width", imgAlt.substring(widthPosition, width));
+		                }
+					});
+		        </script>
 		';
 		
 		return $html;	


### PR DESCRIPTION
This plugin uses jQuery to allow you to set custom dimensions for your images directly on markdown.

To set image dimensions you just use: `![Test image heigh=X width=Y](http://link.to/your_image)`.

Where X and Y should be any value in pixels (% values will not work).
