### PR TITLE
fancyBox 2 plugin for Bludit.

### DIFF
--- a/fancyBox/js/autofancyBox.js
+++ b/fancyBox/js/autofancyBox.js
@@ -1,0 +1,7 @@
+$(document).ready(function () {
+	$("img").on("click", function () {
+		$.fancybox($(this).attr("src"), {
+			padding: 0
+		});
+	});
+});

--- a/fancyBox/languages/en_US.json
+++ b/fancyBox/languages/en_US.json
@@ -2,6 +2,6 @@
 	"plugin-data":
 	{
 		"name": "fancyBox",
-		"description": "jQuery lightbox script for displaying images, videos and more. (http://fancyapps.com/fancybox/3/)"
+		"description": "jQuery lightbox script for displaying images, videos and more. (http://fancyapps.com/fancybox/)"
 	}
 }

--- a/fancyBox/languages/en_US.json
+++ b/fancyBox/languages/en_US.json
@@ -1,0 +1,7 @@
+{
+	"plugin-data":
+	{
+		"name": "fancyBox",
+		"description": "jQuery lightbox script for displaying images, videos and more. (http://fancyapps.com/fancybox/3/)"
+	}
+}

--- a/fancyBox/metadata.json
+++ b/fancyBox/metadata.json
@@ -1,0 +1,10 @@
+{
+	"author": "Hakim Zulkufli",
+	"email": "acrox999@gmail.com",
+	"website": "https://protecting.faith/",
+	"version": "0.1",
+	"releaseDate": "2017-08-06",
+	"license": "GPLv3",
+	"compatible": "1.5.2,1.6,1.6.1,1.6.2",
+	"notes": ""
+}

--- a/fancyBox/plugin.php
+++ b/fancyBox/plugin.php
@@ -1,0 +1,69 @@
+<?php
+
+class pluginFancyBox extends Plugin {
+	
+	public function init()
+	{
+		$this->dbFields = array(
+			'id'=>'',
+			'options'=>'padding: 0',
+			'jquery'=>0
+		);
+	}
+	
+	public function form()
+	{
+		global $Language;
+
+		$html  = '<div>';
+		$html .= '<label><b>Image Identifier</b></label>';
+		$html .= '<span>This is best left empty unless fancyBox is applied to every images for the theme that you are using.</span><br />';
+		$html .= '<input name="id" id="jslabel" type="text" value="'.$this->getDbField('id').'">';
+		$html .= '</div>';
+		
+		$html .= '<div>';
+		$html .= '<label><b>Options</b></label>';
+		$html .= '<span>Please refer to the <a href="http://fancyapps.com/fancybox/#docs">documentation here</a> for available options. Options are comma separated.</span><br />';
+		$html .= '<input name="options" id="jsoptions" type="text" value="'.$this->getDbField('options').'">';
+		$html .= '</div>';
+		
+		$html .= '<div>';
+		$html .= '<input type="hidden" name="jquery" value="0">';
+		$html .= '<input name="jquery" id="jsjquery" type="checkbox" value="1" '.($this->getDbField('jquery')?'checked':'').'>';
+		$html .= '<label class="forCheckbox" for="jsjquery">Enable jQuery (for themes without jQuery)</label>';
+		$html .= '</div>';
+
+		return $html;
+	}
+	
+	public function siteHead(){
+
+		$html  = '<link  href="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.7/css/jquery.fancybox.min.css" rel="stylesheet">';
+		return $html;
+
+    }
+
+ 	public function siteBodyEnd()
+ 	{
+ 		global $Site;
+ 		global $layout;
+		
+		if($this->getDbField('jquery')){
+			$html  = '<script src="'.HTML_PATH_ADMIN_THEME_JS.'jquery.min.js"></script>';
+			$html .= '<script src="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.7/js/jquery.fancybox.min.js"></script>';
+		} else {
+			$html  = '<script src="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.7/js/jquery.fancybox.min.js"></script>';
+		}
+ 		$html  .= '<script>
+						$(document).ready(function () {
+							$("'.$this->getDbField('id').' img").on("click", function () {
+								$.fancybox($(this).attr("src"), {
+									'.$this->getDbField('options').'
+								});
+							});
+						});
+				   </script>';
+ 		return $html;
+	}
+
+}


### PR DESCRIPTION
An alternative to the Lightbox plugin. Easier and much more user-friendly.

- Automatically adds fancyBox to all images.
- Ability to add additional options as per the official documentations
(http://fancyapps.com/fancybox/#docs)
- Custom <img> tag identifiers for fine-tuning.
(eg. Only allow images with '#post' or '.post' to have fancyBox)